### PR TITLE
Conditional imports for compatibility with Plone >= 4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,25 @@ long_description = (
 install_requires = [
         'setuptools',
         'Products.LinguaPlone',
-        'plone.app.z3cform',
         'zope.i18n',
         'z3c.form',
-        'zope.app.schema',
     ]
+
+try:
+    # Plone < 4.3
+    import plone.app.z3cform
+    install_requires.append('plone.app.z3cform')
+except ImportError:
+    # Plone >= 4.3
+    install_requires.append('plone.z3cform')
+
+try:
+    # Plone < 4.3
+    import zope.app.schema
+    install_requires.append('zope.app.schema')
+except ImportError:
+    # Plone >= 4.3
+    install_requires.append('zope.schema')
 
 
 setup(name='slc.linguatools',
@@ -45,6 +59,7 @@ setup(name='slc.linguatools',
     "Framework :: Plone :: 4.0",
     "Framework :: Plone :: 4.1",
     "Framework :: Plone :: 4.2",
+    "Framework :: Plone :: 4.3",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: GNU General Public License (GPL)",

--- a/src/slc/linguatools/browser/forms.py
+++ b/src/slc/linguatools/browser/forms.py
@@ -3,7 +3,12 @@ import logging
 
 import Acquisition
 
-from zope.app.pagetemplate import ViewPageTemplateFile
+try:
+    # Plone < 4.3
+    from zope.app.pagetemplate import ViewPageTemplateFile
+except ImportError:
+    # Plone >= 4.3
+    from zope.browserpage import ViewPageTemplateFile
 
 from z3c.form import form, field, button
 

--- a/src/slc/linguatools/browser/linguatools.py
+++ b/src/slc/linguatools/browser/linguatools.py
@@ -10,9 +10,19 @@ from zope.event import notify
 from zope.interface import implements
 from zope.lifecycleevent import ObjectCopiedEvent
 
-from zope.app.container.contained import ObjectMovedEvent
-from zope.app.container.contained import notifyContainerModified
-from zope.app.publisher.interfaces.browser import IBrowserMenu
+try:
+    # Plone < 4.3
+    from zope.app.container.contained import ObjectMovedEvent, notifyContainerModified
+except ImportError:
+    # Plone >= 4.3
+    from zope.container.contained import ObjectMovedEvent, notifyContainerModified
+
+try:
+    # Plone < 4.3
+    from zope.app.publisher.interfaces.browser import IBrowserMenu
+except ImportError:
+    # Plone >= 4.3
+    from zope.browsermenu.interfaces import IBrowserMenu
 
 from plone.app.portlets.utils import assignment_mapping_from_key
 from plone.portlets.constants import CONTEXT_CATEGORY

--- a/src/slc/linguatools/browser/vocabularies.py
+++ b/src/slc/linguatools/browser/vocabularies.py
@@ -1,8 +1,21 @@
 from plone.portlets.interfaces import IPortletManager
 
 from zope import component
-from zope.app.component.hooks import getSite
-from zope.app.schema.vocabulary import IVocabularyFactory
+
+try:
+    # Plone < 4.3
+    from zope.app.component.hooks import getSite
+except ImportError:
+    # Plone >= 4.3
+    from zope.component.hooks import getSite
+
+try:
+    # Plone < 4.3
+    from zope.app.schema.vocabulary import IVocabularyFactory
+except ImportError:
+    # Plone >= 4.3
+    from zope.schema.interfaces import IVocabularyFactory
+
 from zope.interface import implements
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary

--- a/src/slc/linguatools/utils.py
+++ b/src/slc/linguatools/utils.py
@@ -15,13 +15,25 @@ from OFS.event import ObjectClonedEvent
 
 from plone.app.portlets.utils import assignment_mapping_from_key
 from zope.event import notify
-from zope.app.container.contained import notifyContainerModified
+
+try:
+    # Plone < 4.3
+    from zope.app.container.contained import ObjectMovedEvent, notifyContainerModified
+except ImportError:
+    # Plone >= 4.3
+    from zope.container.contained import ObjectMovedEvent, notifyContainerModified
+
 from zope.lifecycleevent import ObjectCopiedEvent
-from zope.app.container.contained import ObjectMovedEvent
 from Products.Five.utilities.interfaces import IMarkerInterfaces
 from Products.LinguaPlone.interfaces import ITranslatable
 
-from zope.app.publisher.interfaces.browser import IBrowserMenu
+try:
+    # Plone < 4.3
+    from zope.app.publisher.interfaces.browser import IBrowserMenu
+except ImportError:
+    # Plone >= 4.3
+    from zope.browsermenu.interfaces import IBrowserMenu
+
 from Products.Archetypes.interfaces.base import IBaseFolder
 try:
     from p4a.subtyper.interfaces import ISubtyper


### PR DESCRIPTION
Hello everybody,

I'm in the process of migrating a Plone 4.2 website to 4.3, and eventually all the way to 5.2, and these modifications seem to do the job.

I used this page a a guide:

[Upgrading Plone 4.2 to 4.3](https://docs.plone.org/4/en/manage/upgrading/version_specific_migration/p42_to_p43_upgrade.html)

Laurent.